### PR TITLE
Added some ways for using new features related to port specification

### DIFF
--- a/en/source/cmd-options.rst
+++ b/en/source/cmd-options.rst
@@ -127,12 +127,17 @@ These options are exclusive.
 **Automatic assignment option**
 """""""""""""""""""""""""""""""
 
-* ``-p PORTMASK`` : (Mandatory)
+* ``-p PORTMASK`` :
 
   * hexadecimal bitmask of ports to be used
   * Example: ``-p3``
 
-	* Use port 0 and port 1
+    * Use port 0 and port 1
+
+  * Since Lagpous v0.2.8, this option has become optional when any port is specified in ``lagopus.dsl``.
+
+    * Only specified ports in ``lagopus.dsl`` are used.
+
 
 * ``-w NWORKERS``:
 

--- a/en/source/installation-dpdk.rst
+++ b/en/source/installation-dpdk.rst
@@ -346,7 +346,7 @@ Running / Stopping Lagopus software switch
 DPDK command option
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-In order to run Lagopus softwarwe switch with DPDK configuration, you need to specify DPDK-related options in ``lagopus`` command: which CPU cores are assigned to packet processing (``-c``), how many memory channels the host has (``-n``), which DPDK ports are used (``-p``).
+In order to run Lagopus softwarwe switch with DPDK configuration, you need to specify DPDK-related options in ``lagopus`` command: which CPU cores are assigned to packet processing (``-c``), how many memory channels the host has (``-n``).
 
 In this example, the host has four CPU cores and two memory channel and you try to assign CPU core #1 and CPU core #0 for network I/O and processing and DPDK port #0 and DPDK port #1.
 With ``-c`` option, you should specify which CPU cores are assigned to Lagopus software switch. The value of ``-c`` option uses the hexadecimal notation that its *N* -bit shows whehter CPU core # *N* is used or not for DPDK. The following table help your understanding of CPU flags.
@@ -368,21 +368,6 @@ With ``-c`` option, you should specify which CPU cores are assigned to Lagopus s
      - 0x3
 
 
-With ``-p`` option, you should specify which DPDK ports are assigned to Lagopus software switch. The value of ``-p`` option also uses the hexadecimal notation that its *N* -bit shows whehter DPDK port # *N* is used or not for DPDK.
-
-.. list-table:: DPDK NIC flag
-   :header-rows: 1
-
-   * - DPDK port # 1
-     - DPDK port # 2
-     - flag in binary
-     - flag in hexadecimal
-   * - 1
-     - 1
-     - 0x11
-     - 0x3
-
-
 
 Run Lagopus software switch
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -391,7 +376,7 @@ Run Lagopus software switch
 
   .. code-block:: console
 
-     $ sudo lagopus -d -- -c3 -n2 -- -p3
+     $ sudo lagopus -d -- -c3 -n2 --
 
 Or
 
@@ -399,7 +384,7 @@ Or
 
   .. code-block:: console
 
-     $ sudo lagopus -- -c3 -n2 -- -p3
+     $ sudo lagopus -- -c3 -n2 --
 
 
 Operation of Lagopus software switch with ``lagosh``

--- a/en/source/installation-dpdk.rst
+++ b/en/source/installation-dpdk.rst
@@ -332,7 +332,7 @@ Example Lagopus configuration (DSL format) can be found at "misc/examples/lagopu
        channel channel01 create -dst-addr 127.0.0.1 -protocol tcp
        controller controller01 create -channel channel01 -role equal -connection-type main
        interface interface01 create -type ethernet-dpdk-phy -port-number 0
-       interface interface02 create -type ethernet-dpdk-phy -port-number 1
+       interface interface02 create -type ethernet-dpdk-phy -device :0000:00:09.0 # Since v0.2.10, interface can be specified by PCI ID.
        port port01 create -interface interface01
        port port02 create -interface interface02
        bridge bridge01 create -controller controller01 -port port01 1 -port port02 2 -dpid 0x1


### PR DESCRIPTION
I added some ways for using new features.

- portmask option has become optional
- interface port can be specified by PCI ID on lagpous.dsl
